### PR TITLE
feat!: 🌟 add effect-only blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # extern
 
-This library provides the most seamless possible approach to typed dependency injection for test suites, with an optional feature of runtime validation of externally-sourced data.
+[![npm page](<https://img.shields.io/badge/%40ghostry%2Fextern-rgba(0,0,0,0).svg?style=for-the-badge&logo=npm&logoColor=CB3837>)](https://www.npmjs.com/package/@ghostry/extern)
 
-[![npm page](https://img.shields.io/badge/%40ghostry%2Fextern-CB3837?logo=npm&logoColor=%23CB3837&labelColor=%23FFF)](https://www.npmjs.com/package/@ghostry/extern)
-[![jsr.io score](https://jsr.io/badges/@ghostry/extern/score)](https://jsr.io/@ghostry/extern/score)
-[![dependency count](https://flat.badgen.net/bundlephobia/dependency-count/@ghostry/extern?color=blue)](https://bundlephobia.com/package/@ghostry/extern)
+Provides the most seamless possible approach to typed dependency injection for test suites, with optional runtime validation of externally-sourced data.
 
 ## Example
 
@@ -41,7 +39,18 @@ import * as S from "sury";
  * represents an interaction with an external system which
  * would not be within the intended scope of a unit test.
  */
-const doSomethingCrazy = (x: number) => x + 1;
+function fetchSomething(x: number) {
+  return x + 1;
+}
+
+/**
+ * A function that represents interaction with an external
+ * system, but unlike the other example function above, this
+ * does not return anything useful to the calling code.
+ */
+function doSomething() {
+  console.log("something was done");
+}
 
 /**
  * A schema definition (from a schema library of choice that
@@ -60,16 +69,21 @@ export const schema = S.number;
 /**
  * The function that will be tested.
  */
-export const example = () => {
+export function example() {
   const initial = 1;
 
   /**
-   * Use the library to wrap external interactions.
+   * Use the library to wrap external interactions that produce a value.
    */
-  const result = extern.validated.by(schema).will(() => doSomethingCrazy(1));
+  const result = extern.validated.by(schema).will(() => fetchSomething(1));
+
+  /**
+   * Use the library to wrap external interactions that perform an effect.
+   */
+  extern.effect.will(doSomething);
 
   return initial + result;
-};
+}
 ```
 
 ### Test
@@ -100,6 +114,10 @@ test("example test", async () => {
    * It identifies which external interaction to mock by the
    * schema definition used.  (In many cases, this will be
    * sufficient, but disambiguation is possible as necessary.)
+   *
+   * Effect blocks (unlike value blocks) do not need to be
+   * mocked as they will always be skipped.  (Spying on
+   * them is still possible though.)
    */
   await extern.testing((mock) => {
     /**
@@ -112,7 +130,7 @@ test("example test", async () => {
     const spy = mock(schema).with(999);
 
     /**
-     * The function will not execute the external interaction.
+     * The function will not execute the external interactions.
      * Instead, the mocked data will be returned in its place.
      * Thus, the result is different, as expected.
      */
@@ -127,7 +145,7 @@ test("example test", async () => {
 
   /**
    * Outside of the testing block, all wrapped interactions
-   * will run normally.
+   * will run normally, including effects.
    */
   expect(example()).toEqual(3);
 });
@@ -151,9 +169,15 @@ Since anything wrapped by `extern` will not be excercised when mocked, wrap code
 
 ## API
 
-### `validated` vs `typed` blocks
+There are 2 primary APIs for wrapping code that works with external systems. Which one to use depends on whether the wrapped code will produce a value or not.
 
-When defining an extern block, there are two modes available to determine how the provided schema is used: `validated` and `typed`.
+### For code that produces a value
+
+If the source code block produces a value that must be substituted during tests, use `extern.validated` or `extern.typed`.
+
+#### `validated` vs `typed`
+
+When wrapping a source code block, there are two modes available to determine how the provided schema is used: `validated` and `typed`.
 
 Using `validated` causes the return data of the extern block to be validated by the associated schema. This ensures that the resulting data is of the type defined by the schema. If validation fails, an `InvalidDataTypeError` will be thrown.
 
@@ -161,7 +185,7 @@ Using `typed` will not invoke any runtime validation of the data returned by the
 
 Due to the Standard Schema specification, schema validation may or may not return a Promise. To account for this, an `extern.validated` block will always return the result wrapped in a Promise, whereas `extern.typed` will return the result of the block synchronously.
 
-### `by`
+#### `by`
 
 Determines the schema used for the extern block.
 
@@ -177,11 +201,11 @@ The exact same schema object should be available to both source code and tests s
 >
 > See https://typescript-eslint.io/rules/no-empty-object-type
 
-### `named`
+#### `named`
 
 Names the extern block for the sole purpose of disambiguating its mock in a test suite.
 
-### `given`
+#### `given`
 
 An extern block will usually need to reference parameters outside of itself to perform the desired external interaction. One way of making these references is to make a closure over outside variables:
 
@@ -220,7 +244,7 @@ await extern.testing((mock) => {
 });
 ```
 
-### `will`
+#### `will`
 
 Defines the extern block function to be executed according to the extern chain preceding it.
 
@@ -228,19 +252,17 @@ It will receive the `given` data as its only parameter.
 
 The return value is subject to the type defined by the associated schema and the mode defined in its extern chain.
 
-## Testing notes
+#### Mocking requirements
 
-### Mocking requirements
+Within `extern.testing()`, all value-producing `extern` blocks **must** be mocked. If such a block is used without a registered mock, an error will be thrown, even if the test would not otherwise fail. The expectation of this library is that no external interactions will actually occur during tests since testing scopes should be isolated for the sake of performance and reliability. If external interactions do need to occur during a test, the requirement can be disabled as necessary (as a later section covers).
 
-Within `extern.testing()`, all `extern` blocks **must** be mocked. If `extern` is used without a registered mock, an error will be thrown, even if the test would not otherwise fail. The expectation of this library is that no external interactions will actually occur during tests since testing scopes should be isolated for the sake of performance and reliability. If external interactions do need to occur during a test, they should be tested outside of `extern.testing`.
+Also, any defined `mock` must end up being used by the end of the `extern.testing()` block, otherwise an `UnusedMocksError` will be thrown, even if the test would not otherwise fail. This prevents superfluous mocking that results in confusion about what setup is actually needed to run a test.
 
-Also, any defined `mock` must end up being used by the end of the `extern.testing()` block, otherwise an error will be thrown, even if the test would not otherwise fail. This prevents superfluous mocking that results in confusion about what setup is actually needed to run a test.
+#### Schema requirements
 
-### Schema requirements
+The schema used between an `extern` block and its corresponding `mock` must be the same JavaScript object (satisfying [`SameValueZero`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#same-value-zero_equality) comparison). Therefore, the schema should be defined separately and exported in a way to be accessible to both the source code and tests.
 
-The schema used between an `extern` block and its corresponding `mock` must be the same schema object (satisfying [`SameValueZero`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#same-value-zero_equality) comparison). Therefore, the schema should be defined separately and exported in a way to be accessible to both the source code and tests.
-
-### Disambiguating mocks
+#### Disambiguating mocks
 
 If a test will be executing multiple external interactions that use the same schema definition within a single `extern.testing()` block, mock registration for that schema definition may need to be disambiguated. Without disambiguation, the same data will be used for all `extern` blocks using that schema.
 
@@ -271,7 +293,7 @@ mock(schema).named("abc").with(789);
 
 Registering more than one mock with the same disambiguation for the same schema will immediately throw an error.
 
-### Skipping mocks
+#### Skipping mocks
 
 In some tests, you may wish to run the original code instead of mocking it, but not defining a mock will throw an `UnusedMocksError`.
 
@@ -284,3 +306,78 @@ mock(schema).skip();
 /** Disambiguation is also supported here. */
 mock(schema).named("abc").skip();
 ```
+
+### For code that only performs an effect
+
+If the source code block does not produce a value, then wrapping it with `extern.effect` allows for a simpler integration.
+
+```ts
+extern.effect.will(() => sendMetric("login.success"));
+```
+
+Because there is no return data, no schema is involved and no `by` is needed. The wrapped function must return `void` or `Promise<void>`.
+
+By default, source code wrapped with `extern.effect` will be skipped within `extern.testing()`. Unlike value-producing blocks, there is no requirement to register a mock for it; an unmocked effect simply does nothing.
+
+Outside of `extern.testing()`, the wrapped function runs normally as if `extern` were not involved.
+
+#### `named`
+
+Names the effect block so that it can be spied on in tests:
+
+```ts
+extern.effect
+  .named("send login metric")
+  .will(() => sendMetric("login.success"));
+```
+
+Unnamed effect blocks cannot be observed in tests. They are always skipped within `extern.testing()` with no opportunity to inspect them.
+
+#### `given`
+
+As with value-producing blocks, `given` provides data to the block function from the extern chain instead of through a closure, which makes the data available for assertions in tests:
+
+```ts
+function trackView(postId: number) {
+  return extern.effect.named("track view").given(postId).will(sendViewMetric);
+}
+```
+
+```ts
+await extern.testing((mock) => {
+  const spy = mock.effect.named("track view").observe();
+
+  trackView(123);
+
+  expect(spy.executions[0]).toMatchObject({ given: 123 });
+});
+```
+
+`given` is only available after `named`, since spying on the captured data requires that the block be identifiable.
+
+#### `will`
+
+Defines the effect block function to be executed according to the extern chain preceding it.
+
+It will receive the `given` data as its only parameter.
+
+The return type must be `void` or `Promise<void>`.
+
+#### Spying on effects
+
+Named effects can be observed during a test in one of two ways:
+
+```ts
+/**
+ * Tracks executions and continues to suppress the original
+ * function (the default behavior for effects in tests).
+ */
+const spy = mock.effect.named("track view").observe();
+
+/**
+ * Tracks executions and allows the original function to run.
+ */
+const spy = mock.effect.named("track view").passthrough();
+```
+
+Each returns a spy whose `executions` array records every call to the matching effect block, with any `given` data attached. As with value-producing mocks, a registered effect spy must be exercised at least once before the `extern.testing()` block ends, otherwise an `UnusedMocksError` will be thrown.

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -17,11 +17,11 @@ export interface $$Configuration {
    *
    * @default undefined
    */
-  scope?: "async" | "sync";
+  readonly scope?: "async" | "sync";
 }
 
 export interface $$Config {
-  scope: $$Scope;
+  readonly scope: $$Scope;
 }
 
 export const fromConfiguration = async (

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,5 +1,5 @@
-import type { $$SpyMap } from "./Mocking";
+import type { $$Map } from "./Spy";
 
 export interface $$Context {
-  spies: $$SpyMap;
+  readonly spies: $$Map;
 }

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -1,4 +1,4 @@
-import type { $$Spy } from "./Mocking";
+import type { $$Spy } from "./Spy";
 import type { StandardSchemaV1 } from "./StandardSchema";
 
 /**

--- a/src/Mocking.ts
+++ b/src/Mocking.ts
@@ -1,74 +1,21 @@
 import { DuplicateMockError } from "./Error";
+import { $$Map, type $$Spy, type $$Spyable } from "./Spy";
 import type { StandardSchemaV1 } from "./StandardSchema";
-import type { $$Disambiguation, $$Mode } from "./Types";
-
-/**
- * Defining a mock returns this spy interface that can be used to
- * make assertions about the use of the mock and its identity.
- */
-export type $$Spy<$Out = unknown> =
-  | $$Spy.$$Mocked<$Out>
-  | $$Spy.$$Skipped<$Out>;
-
-namespace $$Spy {
-  export type $$Mocked<$Out> = $$Base<$Out> & $$Distinction.$$Mocked<$Out>;
-  export type $$Skipped<$Out> = $$Base<$Out> & $$Distinction.$$Skipped;
-
-  export type $$Base<$Out> = $$Disambiguation & {
-    readonly schema: StandardSchemaV1<$Out>;
-    readonly specificity: number;
-    readonly executions: Array<$$Execution>;
-    readonly stack: string;
-  };
-
-  export type $$Distinction<$Out> =
-    | $$Distinction.$$Mocked<$Out>
-    | $$Distinction.$$Skipped;
-
-  export namespace $$Distinction {
-    export interface $$Mocked<$Out> {
-      readonly kind: "mocked";
-      readonly value: $Out;
-    }
-
-    export interface $$Skipped {
-      readonly kind: "skipped";
-    }
-  }
-}
-
-export type $$SpyMap = Map<StandardSchemaV1, Array<$$Spy>>;
+import { type $$Disambiguation } from "./Types";
+import { augmentFunction, callerStack } from "./Util";
 
 /**
  * The function used to build a mock in a testing block.
  */
-export type $$Mocker = <$Out>(schema: StandardSchemaV1<$Out>) => $$Mock<$Out>;
-
-/**
- * Information captured about each use of a mock during a testing block.
- */
-export interface $$Execution {
-  mode: $$Mode;
-  named?: string;
-  given?: unknown;
-}
-
-type $$With<$Out> = (value: $Out) => $$Spy.$$Mocked<$Out>;
-type $$Skip<$Out> = () => $$Spy.$$Skipped<$Out>;
-
-type $$Named<$Out> = (name: string) => {
-  with: $$With<$Out>;
-  skip: $$Skip<$Out>;
+export type $$Mocker = {
+  <$Out>(
+    schema: StandardSchemaV1<$Out>,
+  ): $$Spyable.$$ForValue.$$Interface<$Out>;
+  readonly effect: $$Spyable.$$ForEffect.$$Interface;
 };
 
-interface $$Mock<$Out> {
-  with: $$With<$Out>;
-  skip: $$Skip<$Out>;
-  named: $$Named<$Out>;
-}
-
 export const exactly =
-  (disamb: $$Disambiguation) =>
+  (disamb: $$Disambiguation.$$ForValue) =>
   (spy: $$Spy): boolean => {
     if ("named" in disamb || "named" in spy) {
       if ("named" in disamb !== "named" in spy) return false;
@@ -79,7 +26,7 @@ export const exactly =
   };
 
 export const approximately =
-  (disamb: $$Disambiguation) =>
+  (disamb: $$Disambiguation.$$ForValue) =>
   (spy: $$Spy): boolean => {
     if ("named" in spy) {
       if (disamb.named !== spy.named) return false;
@@ -88,44 +35,35 @@ export const approximately =
     return true;
   };
 
-const callerStack = (ignore: Function, limit?: number) => {
-  const trace: { stack: NonNullable<Error["stack"]> } = { stack: "" };
-
-  const originalLimit = Error.stackTraceLimit;
-  Error.stackTraceLimit = limit ?? originalLimit;
-  Error.captureStackTrace(trace, ignore);
-  Error.stackTraceLimit = originalLimit;
-
-  const [_message, ...frames] = trace.stack.split("\n");
-
-  return frames.join("\n");
-};
+/**
+ * Defines a bit field to easily compare the specificity of a mock definition.
+ */
+const Specificity = { named: 0b1, none: 0b0 } as const;
 
 export const mocking = () => {
-  const spies: $$SpyMap = new Map();
+  const spies = $$Map.build();
 
-  const mock: $$Mocker = <$Out>(
+  const forValue = <$Out>(
     schema: StandardSchemaV1<$Out>,
-  ): $$Mock<$Out> => {
-    const $use = <$Distinction extends $$Spy.$$Distinction<$Out>>(
-      disamb: $$Disambiguation,
-      distinction: $Distinction,
-    ): $$Spy.$$Base<$Out> & $Distinction => {
+  ): $$Spyable.$$ForValue.$$Interface<$Out> => {
+    const $use = (
+      disamb: $$Disambiguation.$$ForValue,
+      strategy: $$Spy.$$Strategy.$$ForValue.$$Any<$Out>,
+    ): $$Spy.$$ForValue<$Out> => {
       const exactlyMatches = exactly(disamb);
       const existing = spies.get(schema) ?? [];
 
-      /**
-       * A bit field to easily compare the specificity of a mock definition.
-       */
-      const specificity = "named" in disamb ? 0b1 : 0b0;
+      const specificity =
+        "named" in disamb ? Specificity.named : Specificity.none;
 
-      const spy = {
+      const spy: $$Spy.$$ForValue<$Out> = {
         ...disamb,
         schema,
         specificity,
         executions: [],
         stack: callerStack($use, 1),
-        ...distinction,
+        strategy,
+        kind: "value",
       };
 
       /**
@@ -141,32 +79,78 @@ export const mocking = () => {
         if (exactlyMatches(next)) throw new DuplicateMockError();
         if (specificity >= next.specificity) break;
       }
-      existing.splice(insertionPoint, 0, spy);
 
+      existing.splice(insertionPoint, 0, spy);
       spies.set(schema, existing);
 
       return spy;
     };
 
-    const $with =
-      (disamb: $$Disambiguation) =>
-      (value: $Out): $$Spy.$$Mocked<$Out> => {
-        return $use(disamb, { kind: "mocked", value });
+    const $substitute =
+      (disamb: $$Disambiguation.$$ForValue) =>
+      (value: $Out): $$Spy.$$ForValue<$Out> => {
+        return $use(disamb, { kind: "substitute", value });
       };
 
-    const $skip = (disamb: $$Disambiguation) => (): $$Spy.$$Skipped<$Out> => {
-      return $use(disamb, { kind: "skipped" });
-    };
+    const $passthrough =
+      (disamb: $$Disambiguation.$$ForValue) => (): $$Spy.$$ForValue<$Out> => {
+        return $use(disamb, { kind: "passthrough" });
+      };
 
     return {
-      with: $with({}),
-      skip: $skip({}),
+      substitute: $substitute({}),
+      with: $substitute({}),
+
+      passthrough: $passthrough({}),
+      skip: $passthrough({}),
+
       named: (name: string) => ({
-        with: $with({ named: name }),
-        skip: $skip({ named: name }),
+        substitute: $substitute({ named: name }),
+        with: $substitute({ named: name }),
+
+        passthrough: $passthrough({ named: name }),
+        skip: $passthrough({ named: name }),
       }),
     };
   };
+
+  const forEffect = (): $$Spyable.$$ForEffect.$$Interface => {
+    const $use = (
+      { named }: $$Disambiguation.$$ForEffect,
+      strategy: $$Spy.$$Strategy.$$ForEffect.$$Any,
+    ): $$Spy.$$ForEffect => {
+      const existing = spies.effects.get(named);
+      if (existing) throw new DuplicateMockError();
+
+      const spy: $$Spy.$$ForEffect = {
+        named,
+        specificity: Specificity.named,
+        executions: [],
+        stack: callerStack($use, 1),
+        strategy,
+        kind: "effect",
+      };
+
+      spies.effects.set(named, spy);
+
+      return spy;
+    };
+
+    const $observe = (disamb: $$Disambiguation.$$ForEffect) => () =>
+      $use(disamb, { kind: "observe" });
+
+    const $passthrough = (disamb: $$Disambiguation.$$ForEffect) => () =>
+      $use(disamb, { kind: "passthrough" });
+
+    return {
+      named: (name: string) => ({
+        observe: $observe({ named: name }),
+        passthrough: $passthrough({ named: name }),
+      }),
+    };
+  };
+
+  const mock: $$Mocker = augmentFunction(forValue, { effect: forEffect() });
 
   return { mock, spies };
 };

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -3,22 +3,22 @@ import type { $$Context } from "./Context";
 import { IllegalConcurrencyTestingError } from "./Error";
 
 export interface $$Scope {
-  current: () => $$Context | undefined;
-  run: (context: $$Context, fn: () => Promise<void>) => Promise<void>;
+  readonly current: () => $$Context | undefined;
+  readonly run: (context: $$Context, fn: () => Promise<void>) => Promise<void>;
 }
 
 class $$AsyncScope implements $$Scope {
-  private store: AsyncLocalStorage<$$Context | undefined>;
+  private readonly store: AsyncLocalStorage<$$Context | undefined>;
 
   constructor(m: typeof import("node:async_hooks")) {
     this.store = new m.AsyncLocalStorage({ defaultValue: undefined });
   }
 
-  public current = () => {
+  public readonly current = () => {
     return this.store.getStore();
   };
 
-  public run = async (
+  public readonly run = async (
     context: $$Context,
     fn: () => Promise<void>,
   ): Promise<void> => {
@@ -27,7 +27,7 @@ class $$AsyncScope implements $$Scope {
 }
 
 class $$SyncScope implements $$Scope {
-  private mutex = new $$Mutex({
+  private readonly mutex = new $$Mutex({
     onContest: () => {
       throw new IllegalConcurrencyTestingError();
     },
@@ -35,11 +35,11 @@ class $$SyncScope implements $$Scope {
 
   private context: $$Context | undefined = undefined;
 
-  public current = () => {
+  public readonly current = () => {
     return this.context;
   };
 
-  public run = async (
+  public readonly run = async (
     context: $$Context,
     fn: () => Promise<void>,
   ): Promise<void> => {
@@ -60,15 +60,15 @@ interface $$MutexConfig {
 }
 
 class $$Mutex {
-  private queue: Promise<void>[] = [];
+  private readonly queue: Promise<void>[] = [];
 
-  private onContest: $$MutexConfig["onContest"];
+  private readonly onContest: $$MutexConfig["onContest"];
 
   constructor(config?: Partial<$$MutexConfig>) {
     this.onContest = config?.onContest || Promise.resolve;
   }
 
-  public acquire = async (): Promise<() => void> => {
+  public readonly acquire = async (): Promise<() => void> => {
     let release: () => void = () => {};
 
     const queue = this.queue;

--- a/src/Spy.ts
+++ b/src/Spy.ts
@@ -1,0 +1,151 @@
+import type { StandardSchemaV1 } from "./StandardSchema";
+import type { $$Disambiguation, $$Mode, $$Name } from "./Types";
+
+/**
+ * Information captured about each use of a mock during a testing block.
+ */
+export interface $$Execution {
+  /**
+   * The defined mode of the source extern block.
+   */
+  readonly mode: $$Mode;
+
+  /**
+   * The name assigned to the source extern block.
+   */
+  readonly named?: string;
+
+  /**
+   * The runtime value supplied to the source function.
+   */
+  readonly given?: unknown;
+}
+
+/**
+ * Defining a mock returns this spy interface that can be used to
+ * make assertions about the use of the mock and its identity.
+ */
+export type $$Spy<$Out = unknown> = $$Spy.$$Any<$Out>;
+
+export namespace $$Spy {
+  export type $$Any<$Out = unknown> = $$ForValue<$Out> | $$ForEffect;
+
+  export type $$ForValue<$Out = unknown> = $$Base
+    & $$Disambiguation.$$ForValue & {
+      readonly kind: "value";
+      readonly schema: StandardSchemaV1<$Out>;
+      readonly strategy: $$Strategy.$$ForValue.$$Any<$Out>;
+    };
+
+  export type $$ForEffect = $$Base
+    & $$Disambiguation.$$ForEffect & {
+      readonly kind: "effect";
+      readonly strategy: $$Strategy.$$ForEffect.$$Any;
+    };
+
+  type $$Base = {
+    readonly specificity: number;
+    readonly executions: Array<$$Execution>;
+    readonly stack: string;
+  };
+
+  export namespace $$Strategy {
+    export namespace $$ForValue {
+      export type $$Any<$Out> = $$Substitute<$Out> | $$Passthrough;
+
+      export type $$Substitute<$Out> = {
+        readonly kind: "substitute";
+        readonly value: $Out;
+      };
+
+      export type $$Passthrough = { readonly kind: "passthrough" };
+    }
+
+    export namespace $$ForEffect {
+      export type $$Any = $$Observe | $$Passthrough;
+
+      export type $$Observe = { readonly kind: "observe" };
+
+      export type $$Passthrough = { readonly kind: "passthrough" };
+    }
+  }
+}
+
+export namespace $$Spyable {
+  export namespace $$ForValue {
+    export type $$Interface<$Out> = {
+      /** Define the substitution value for tests. */
+      substitute: $$ForValue.$$Substitute<$Out>;
+      /** @alias `substitute` */
+      with: $$ForValue.$$Substitute<$Out>;
+
+      /** Configure the source extern block to run the original function. */
+      passthrough: $$ForValue.$$Passthrough<$Out>;
+      /** @alias `passthrough` */
+      skip: $$ForValue.$$Passthrough<$Out>;
+
+      /** Target source extern blocks with the specified name. */
+      named: (name: string) => {
+        /** Define the substitution value for tests. */
+        substitute: $$Substitute<$Out>;
+        /** @alias `substitute` */
+        with: $$Substitute<$Out>;
+
+        /** Configure the source extern block to run the original function. */
+        passthrough: $$Passthrough<$Out>;
+        /** @alias `passthrough` */
+        skip: $$Passthrough<$Out>;
+      };
+    };
+
+    export type $$Substitute<$Out> = (value: $Out) => $$Spy.$$ForValue<$Out>;
+
+    export type $$Passthrough<$Out> = () => $$Spy.$$ForValue<$Out>;
+  }
+
+  export namespace $$ForEffect {
+    export type $$Interface = {
+      /** Target source extern blocks with the specified name. */
+      named: (name: string) => {
+        /** Obtain a spy for the source extern block. */
+        observe: $$Observe;
+
+        /** Configure the source extern block to run the original function. */
+        passthrough: $$Passthrough;
+      };
+    };
+
+    export type $$Observe = () => $$Spy.$$ForEffect;
+
+    export type $$Passthrough = () => $$Spy.$$ForEffect;
+  }
+}
+
+export type $$Map = $$Map.$$Interface<
+  StandardSchemaV1,
+  Array<$$Spy.$$ForValue>
+> & { readonly effects: $$Map.$$Interface<$$Name, $$Spy.$$ForEffect> };
+
+export namespace $$Map {
+  export type $$ForValue = Map<StandardSchemaV1, Array<$$Spy.$$ForValue>>;
+  export type $$ForEffect = Map<$$Name, $$Spy.$$ForEffect>;
+
+  export interface $$Interface<$K, $V> {
+    readonly get: (k: $K) => $V | undefined;
+    readonly set: (k: $K, spies: $V) => void;
+    readonly forEach: (fn: (spies: $V) => void) => void;
+  }
+
+  namespace $$Interface {
+    export const build = <$K, $V>(m: Map<$K, $V>): $$Interface<$K, $V> => ({
+      get: (...args) => m.get(...args),
+      set: (...args) => m.set(...args),
+      forEach: (...args) => m.forEach(...args),
+    });
+  }
+
+  export const build = (): $$Map => ({
+    ...$$Interface.build(new Map()),
+    effects: $$Interface.build(new Map()),
+  });
+}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -5,12 +5,20 @@ export type Promised<$T, $Promisable extends Promisable<$T>> =
 
 export type $$Name = string;
 
-export type $$Mode = "typed" | "validated";
+export type $$Mode = "typed" | "validated" | "effect";
 
-export interface $$Disambiguation {
-  readonly named?: string;
+export namespace $$Disambiguation {
+  type $$Base = { readonly named: string };
+
+  export type $$ForValue = Partial<$$Base>;
+  export type $$ForEffect = Required<$$Base>;
 }
 
-export type $$Params<$In> = $$Disambiguation & { given?: $In };
+export namespace $$Params {
+  type $$Base<$In> = { readonly given?: $In };
+
+  export type $$ForValue<$In> = $$Base<$In> & $$Disambiguation.$$ForValue;
+  export type $$ForEffect<$In> = $$Base<$In> & $$Disambiguation.$$ForEffect;
+}
 
 export const never = (never: never): never => never;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,0 +1,31 @@
+export function callerStack(ignore: Function, limit?: number) {
+  const trace: { stack: NonNullable<Error["stack"]> } = { stack: "" };
+
+  const originalLimit = Error.stackTraceLimit;
+  Error.stackTraceLimit = limit ?? originalLimit;
+  Error.captureStackTrace(trace, ignore);
+  Error.stackTraceLimit = originalLimit;
+
+  const [_message, ...frames] = trace.stack.split("\n");
+
+  return frames.join("\n");
+}
+
+export function augmentFunction<
+  Fn extends (...args: any[]) => unknown,
+  Props extends Record<string, unknown>,
+>(fn: Fn, props: Props) {
+  const propertyDescriptors = Object.entries(props).map(
+    ([k, v]): [keyof Props, PropertyDescriptor] => [
+      k,
+      { value: v, enumerable: true },
+    ],
+  );
+
+  const redefined = Object.defineProperties(
+    fn,
+    Object.fromEntries(propertyDescriptors),
+  );
+
+  return redefined as Fn & Props;
+}

--- a/src/effect/Core.ts
+++ b/src/effect/Core.ts
@@ -1,0 +1,36 @@
+import type { $$Config } from "../Config";
+import { type $$Params, type Promisable } from "../Types";
+
+export const $will = <$Out extends Promisable<void>, $In>(
+  config: $$Config,
+  params: Partial<$$Params.$$ForEffect<$In>>,
+  fn: () => $Out,
+): $Out => {
+  const context = config.scope.current();
+
+  /**
+   * If not in an explicit testing block, simply run the original function.
+   */
+  if (!context) return fn();
+
+  /**
+   * If the source code block does not name this, then don't make it
+   * available to spy on in tests.
+   */
+  if (typeof params.named !== "string") return Promise.resolve() as $Out;
+
+  const spy = context.spies.effects.get(params.named);
+
+  if (!spy) return Promise.resolve() as $Out;
+
+  spy.executions.push({ ...params, mode: "effect" });
+
+  switch (spy.strategy.kind) {
+    case "passthrough": {
+      return fn();
+    }
+    case "observe": {
+      return Promise.resolve() as $Out;
+    }
+  }
+};

--- a/src/effect/index.ts
+++ b/src/effect/index.ts
@@ -1,0 +1,13 @@
+import type { $$Config } from "../Config";
+import { $$named } from "./named";
+import { $$will } from "./will";
+
+export interface $$Effect {
+  named: $$named;
+  will: $$will;
+}
+
+export const $$effect = (config: $$Config): $$Effect => ({
+  named: $$named(config),
+  will: $$will(config),
+});

--- a/src/effect/named/given/index.ts
+++ b/src/effect/named/given/index.ts
@@ -1,0 +1,19 @@
+import type { $$Config } from "../../../Config";
+import type { $$Name } from "../../../Types";
+import { $$will } from "./will";
+
+export interface $$Given<$Name extends $$Name, $In> {
+  name: $Name;
+  will: $$will<$In>;
+}
+
+export type $$given<$Name extends $$Name> = <const $In>(
+  given: $In,
+) => $$Given<$Name, $In>;
+
+export const $$given =
+  <$Name extends $$Name>(config: $$Config, name: $Name): $$given<$Name> =>
+  <const $In>(given: $In): $$Given<$Name, $In> => ({
+    name,
+    will: $$will<$In>(config, given, { named: name }),
+  });

--- a/src/effect/named/given/will/index.ts
+++ b/src/effect/named/given/will/index.ts
@@ -1,0 +1,17 @@
+import type { $$Config } from "../../../../Config";
+import type { $$Disambiguation, Promisable } from "../../../../Types";
+import { $will } from "../../../Core";
+
+export type $$will<$In> = <$Out extends Promisable<void>>(
+  fn: (given: $In) => $Out,
+) => $Out;
+
+export const $$will =
+  <$In>(
+    config: $$Config,
+    given: $In,
+    disamb: $$Disambiguation.$$ForEffect,
+  ): $$will<$In> =>
+  <$Out extends Promisable<void>>(fn: (given: $In) => $Out): $Out => {
+    return $will<$Out, $In>(config, { ...disamb, given }, () => fn(given));
+  };

--- a/src/effect/named/index.ts
+++ b/src/effect/named/index.ts
@@ -1,0 +1,20 @@
+import type { $$Config } from "../../Config";
+import type { $$Name } from "../../Types";
+import { $$given } from "./given";
+import { $$will } from "./will";
+
+export interface $$Named<$Name extends $$Name> {
+  name: $Name;
+  given: $$given<$Name>;
+  will: $$will;
+}
+
+export type $$named = <$Name extends $$Name>(name: $Name) => $$Named<$Name>;
+
+export const $$named =
+  (config: $$Config): $$named =>
+  <$Name extends $$Name>(name: $Name): $$Named<$Name> => ({
+    name,
+    given: $$given<$Name>(config, name),
+    will: $$will(config, { named: name }),
+  });

--- a/src/effect/named/will/index.ts
+++ b/src/effect/named/will/index.ts
@@ -1,0 +1,11 @@
+import type { $$Config } from "../../../Config";
+import type { $$Disambiguation, Promisable } from "../../../Types";
+import { $will } from "../../Core";
+
+export type $$will = <$O extends Promisable<void>>(fn: () => $O) => $O;
+
+export const $$will =
+  (config: $$Config, disamb: $$Disambiguation.$$ForEffect): $$will =>
+  <$O extends Promisable<void>>(fn: () => $O): $O => {
+    return $will<$O, never>(config, disamb, () => fn());
+  };

--- a/src/effect/will/index.ts
+++ b/src/effect/will/index.ts
@@ -1,0 +1,11 @@
+import type { $$Config } from "../../Config";
+import type { Promisable } from "../../Types";
+import { $will } from "../Core";
+
+export type $$will = <$O extends Promisable<void>>(fn: () => $O) => $O;
+
+export const $$will =
+  (config: $$Config): $$will =>
+  <$O extends Promisable<void>>(fn: () => $O): $O => {
+    return $will<$O, never>(config, {}, () => fn());
+  };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,14 @@
 import { fromConfiguration, type $$Configuration } from "./Config";
+import { $$effect, type $$Effect } from "./effect";
 import { $$testing, type $$Testing } from "./testing";
 import { $$typed, type $$Typed } from "./typed";
 import { $$validated, type $$Validated } from "./validated";
 
 export type { $$Configuration as Configuration } from "./Config.ts";
 
-export type {
-  $$Execution as Execution,
-  $$Mocker as Mocker,
-  $$Spy as Spy,
-} from "./Mocking.ts";
+export type { $$Execution as Execution, $$Spy as Spy } from "./Spy";
+
+export type { $$Mocker as Mocker } from "./Mocking.ts";
 
 export type {
   DuplicateMockError,
@@ -24,9 +23,26 @@ export type {
  * Initialization of the library provides this interface.
  */
 export interface Initialized {
-  validated: $$Validated;
-  typed: $$Typed;
-  testing: $$Testing;
+  /**
+   * Start defining an extern block in `validated` mode.
+   */
+  readonly validated: $$Validated;
+
+  /**
+   * Start defining an extern block in `typed` mode.
+   */
+  readonly typed: $$Typed;
+
+  /**
+   * Start defining an extern block in `effect` mode.
+   */
+  readonly effect: $$Effect;
+
+  /**
+   * Run a supplied function in a testing context in which to mock source
+   * extern blocks.
+   */
+  readonly testing: $$Testing;
 }
 
 /**
@@ -41,6 +57,7 @@ export const initialize = async (
   return {
     validated: $$validated($config),
     typed: $$typed($config),
+    effect: $$effect($config),
     testing: $$testing($config),
   };
 };

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,7 +1,8 @@
 import type { $$Config } from "../Config";
 import { UnusedMocksError } from "../Error";
-import { mocking, type $$Mocker, type $$Spy, type $$SpyMap } from "../Mocking";
-import { never, type Promisable } from "../Types";
+import { mocking, type $$Mocker } from "../Mocking";
+import type { $$Map, $$Spy } from "../Spy";
+import { type Promisable } from "../Types";
 
 export type $$Testing = (
   fn: (mocker: $$Mocker) => Promisable<void>,
@@ -16,25 +17,15 @@ export const $$testing =
     disallowUnusedMocks(spies);
   };
 
-const disallowUnusedMocks = (spiesBySchema: $$SpyMap) => {
+const disallowUnusedMocks = (spyMap: $$Map) => {
   const unused: Array<$$Spy> = [];
 
-  spiesBySchema.forEach((spies) => {
-    spies.forEach((spy) => {
-      switch (spy.kind) {
-        case "skipped": {
-          break;
-        }
-        case "mocked": {
-          if (spy.executions.length === 0) unused.push(spy);
-          break;
-        }
-        default: {
-          never(spy);
-        }
-      }
-    });
-  });
+  const check = (spy: $$Spy) => {
+    if (spy.executions.length === 0) unused.push(spy);
+  };
+
+  spyMap.effects.forEach(check);
+  spyMap.forEach((spies) => spies.forEach(check));
 
   if (unused.length > 0) {
     throw new UnusedMocksError(unused);

--- a/src/typed/Core.ts
+++ b/src/typed/Core.ts
@@ -7,7 +7,7 @@ import { type $$Params } from "../Types";
 export const $will = <$Out, $In>(
   config: $$Config,
   schema: StandardSchemaV1<unknown>,
-  params: $$Params<$In>,
+  params: $$Params.$$ForValue<$In>,
   fn: () => $Out,
 ): $Out => {
   const context = config.scope.current();
@@ -23,12 +23,12 @@ export const $will = <$Out, $In>(
 
   spy.executions.push({ ...params, mode: "typed" });
 
-  switch (spy.kind) {
-    case "skipped": {
+  switch (spy.strategy.kind) {
+    case "passthrough": {
       return fn();
     }
-    case "mocked": {
-      return spy.value as $Out;
+    case "substitute": {
+      return spy.strategy.value as $Out;
     }
   }
 };

--- a/src/typed/by/given/will/index.ts
+++ b/src/typed/by/given/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../Config";
 import type { StandardSchemaV1 } from "../../../../StandardSchema";
 import type { Promisable, Promised } from "../../../../Types";
-import { $will } from "../../../Will";
+import { $will } from "../../../Core";
 
 export type $$will<$Out, $In> = <$O extends Promisable<$Out>>(
   fn: (given: $In) => $O,

--- a/src/typed/by/named/given/will/index.ts
+++ b/src/typed/by/named/given/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../../Config";
 import type { StandardSchemaV1 } from "../../../../../StandardSchema";
 import type { Promisable, Promised } from "../../../../../Types";
-import { $will } from "../../../../Will";
+import { $will } from "../../../../Core";
 
 export type $$will<$Out, $In> = <$O extends Promisable<$Out>>(
   fn: (given: $In) => $O,

--- a/src/typed/by/named/will/index.ts
+++ b/src/typed/by/named/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../Config";
 import type { StandardSchemaV1 } from "../../../../StandardSchema";
 import type { $$Disambiguation, Promisable, Promised } from "../../../../Types";
-import { $will } from "../../../Will";
+import { $will } from "../../../Core";
 
 export type $$will<$Out> = <$O extends Promisable<$Out>>(
   fn: () => $O,
@@ -11,7 +11,7 @@ export const $$will =
   <$Out>(
     config: $$Config,
     schema: StandardSchemaV1<$Out>,
-    disamb: $$Disambiguation,
+    disamb: $$Disambiguation.$$ForValue,
   ): $$will<$Out> =>
   <$O extends Promisable<$Out>>(fn: () => $O): Promised<$Out, $O> => {
     return $will<$O, never>(config, schema, disamb, () => fn()) as Promised<

--- a/src/typed/by/will/index.ts
+++ b/src/typed/by/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../Config";
 import type { StandardSchemaV1 } from "../../../StandardSchema";
 import type { Promisable, Promised } from "../../../Types";
-import { $will } from "../../Will";
+import { $will } from "../../Core";
 
 export type $$will<$Out> = <$O extends Promisable<$Out>>(
   fn: () => $O,

--- a/src/validated/Core.ts
+++ b/src/validated/Core.ts
@@ -7,7 +7,7 @@ import type { $$Params } from "../Types";
 export const $will = async <$Out, $In>(
   config: $$Config,
   schema: StandardSchemaV1<$Out>,
-  params: $$Params<$In>,
+  params: $$Params.$$ForValue<$In>,
   fn: () => Promise<$Out>,
 ): Promise<$Out> => {
   const context = config.scope.current();
@@ -28,12 +28,12 @@ export const $will = async <$Out, $In>(
 
   spy.executions.push({ ...params, mode: "validated" });
 
-  switch (spy.kind) {
-    case "skipped": {
+  switch (spy.strategy.kind) {
+    case "passthrough": {
       return fn();
     }
-    case "mocked": {
-      return spy.value as $Out;
+    case "substitute": {
+      return spy.strategy.value as $Out;
     }
   }
 };

--- a/src/validated/by/given/will/index.ts
+++ b/src/validated/by/given/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../Config";
 import type { StandardSchemaV1 } from "../../../../StandardSchema";
 import type { Promisable } from "../../../../Types";
-import { $will } from "../../../Will";
+import { $will } from "../../../Core";
 
 export type $$will<$Out, $In> = (
   fn: (given: $In) => Promisable<$Out>,

--- a/src/validated/by/named/given/will/index.ts
+++ b/src/validated/by/named/given/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../../Config";
 import type { StandardSchemaV1 } from "../../../../../StandardSchema";
 import type { $$Disambiguation, Promisable } from "../../../../../Types";
-import { $will } from "../../../../Will";
+import { $will } from "../../../../Core";
 
 export type $$will<$Out, $In> = (
   fn: (given: $In) => Promisable<$Out>,
@@ -12,7 +12,7 @@ export const $$will =
     config: $$Config,
     schema: StandardSchemaV1<$Out>,
     given: $In,
-    disamb: $$Disambiguation,
+    disamb: $$Disambiguation.$$ForValue,
   ): $$will<$Out, $In> =>
   async (fn: (given: $In) => Promisable<$Out>): Promise<$Out> => {
     return $will<$Out, $In>(config, schema, { ...disamb, given }, async () =>

--- a/src/validated/by/named/will/index.ts
+++ b/src/validated/by/named/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../../Config";
 import type { StandardSchemaV1 } from "../../../../StandardSchema";
 import type { $$Disambiguation, Promisable } from "../../../../Types";
-import { $will } from "../../../Will";
+import { $will } from "../../../Core";
 
 export type $$will<$Out> = (fn: () => Promisable<$Out>) => Promise<$Out>;
 
@@ -9,7 +9,7 @@ export const $$will =
   <$Out>(
     config: $$Config,
     schema: StandardSchemaV1<$Out>,
-    disamb: $$Disambiguation,
+    disamb: $$Disambiguation.$$ForValue,
   ): $$will<$Out> =>
   async (fn: () => Promisable<$Out>): Promise<$Out> => {
     return $will<$Out, never>(config, schema, disamb, async () => fn());

--- a/src/validated/by/will/index.ts
+++ b/src/validated/by/will/index.ts
@@ -1,7 +1,7 @@
 import type { $$Config } from "../../../Config";
 import type { StandardSchemaV1 } from "../../../StandardSchema";
 import type { $$Disambiguation, Promisable } from "../../../Types";
-import { $will } from "../../Will";
+import { $will } from "../../Core";
 
 export type $$will<$Out> = (fn: () => Promisable<$Out>) => Promise<$Out>;
 
@@ -9,7 +9,7 @@ export const $$will =
   <$Out>(
     config: $$Config,
     schema: StandardSchemaV1<$Out>,
-    disamb: $$Disambiguation,
+    disamb: $$Disambiguation.$$ForValue,
   ): $$will<$Out> =>
   async (fn: () => Promisable<$Out>): Promise<$Out> => {
     return $will<$Out, never>(config, schema, disamb, async () => fn());

--- a/test/effect.test.ts
+++ b/test/effect.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, expectTypeOf, it } from "bun:test";
+import { initialize } from "../src";
+import type { Promisable } from "../src/Types";
+
+describe("`extern.effect`", async () => {
+  const extern = await initialize();
+
+  describe("`will()`", () => {
+    const subject = extern.effect;
+
+    it("runs the function", async () => {
+      let ran = false;
+
+      await subject.will(() => {
+        ran = true;
+      });
+
+      expect(ran).toBe(true);
+    });
+
+    it("returns void", () => {
+      const result = subject.will(() => {});
+
+      expectTypeOf<typeof result>().toEqualTypeOf<void>();
+
+      expect(result).toBeUndefined();
+    });
+
+    describe("an async `will()` function", () => {
+      it("awaits the function", async () => {
+        let ran = false;
+
+        await subject.will(async () => {
+          ran = true;
+        });
+
+        expect(ran).toBe(true);
+      });
+
+      it("returns a Promise<void>", async () => {
+        const result = subject.will(async () => {});
+
+        expectTypeOf<typeof result>().toEqualTypeOf<Promise<void>>();
+
+        await expect(result).resolves.toBeUndefined();
+      });
+    });
+
+    describe("returning a non-void value", () => {
+      it("returns a Promisable<void>", () => {
+        const result = subject.will(
+          () =>
+            /* @ts-expect-error */
+            123,
+        );
+
+        expectTypeOf<typeof result>().toEqualTypeOf<Promisable<void>>();
+      });
+    });
+  });
+
+  describe("`named()`", () => {
+    const subject = extern.effect.named("abc");
+
+    describe("`will()`", () => {
+      it("runs the function", async () => {
+        let ran = false;
+
+        await subject.will(() => {
+          ran = true;
+        });
+
+        expect(ran).toBe(true);
+      });
+
+      it("returns void", () => {
+        const result = subject.will(() => {});
+
+        expectTypeOf<typeof result>().toEqualTypeOf<void>();
+
+        expect(result).toBeUndefined();
+      });
+
+      describe("an async `will()` function", () => {
+        it("awaits the function", async () => {
+          let ran = false;
+
+          await subject.will(async () => {
+            ran = true;
+          });
+
+          expect(ran).toBe(true);
+        });
+
+        it("returns a Promise<void>", async () => {
+          const result = subject.will(async () => {});
+
+          expectTypeOf<typeof result>().toEqualTypeOf<Promise<void>>();
+
+          await expect(result).resolves.toBeUndefined();
+        });
+      });
+
+      describe("returning a non-void value", () => {
+        it("returns a Promisable<void>", () => {
+          const result = subject.will(
+            () =>
+              /* @ts-expect-error */
+              123,
+          );
+
+          expectTypeOf<typeof result>().toEqualTypeOf<Promisable<void>>();
+        });
+      });
+    });
+
+    describe("`given()`", () => {
+      const subject = extern.effect.named("abc").given(987);
+
+      describe("`will()`", () => {
+        it("runs the function with the given value", async () => {
+          let received: number | undefined;
+
+          await subject.will((given) => {
+            received = given;
+          });
+
+          expect(received).toBe(987);
+        });
+
+        it("returns void", () => {
+          const result = subject.will(() => {});
+
+          expectTypeOf<typeof result>().toEqualTypeOf<void>();
+
+          expect(result).toBeUndefined();
+        });
+
+        describe("an async `will()` function", () => {
+          it("awaits the function with the given value", async () => {
+            let received: number | undefined;
+
+            await subject.will(async (given) => {
+              received = given;
+            });
+
+            expect(received).toBe(987);
+          });
+
+          it("returns a Promise<void>", async () => {
+            const result = subject.will(async () => {});
+
+            expectTypeOf<typeof result>().toEqualTypeOf<Promise<void>>();
+
+            await expect(result).resolves.toBeUndefined();
+          });
+        });
+
+        describe("returning a non-void value", () => {
+          it("returns a Promisable<void>", () => {
+            const result = subject.will(
+              () =>
+                /* @ts-expect-error */
+                123,
+            );
+
+            expectTypeOf<typeof result>().toEqualTypeOf<Promisable<void>>();
+          });
+        });
+
+        describe("with a literal given value", () => {
+          it("narrows the parameter type to the literal", () => {
+            const subject = extern.effect.named("abc").given("literal");
+
+            subject.will((given) => {
+              expectTypeOf<typeof given>().toEqualTypeOf<"literal">();
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/testing/effect.test.ts
+++ b/test/testing/effect.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import { initialize, type Initialized } from "../../src";
+import { DuplicateMockError, UnusedMocksError } from "../../src/Error";
+
+describe("`extern.testing`", async () => {
+  const extern = await initialize();
+
+  describe("for `extern.effect`", () => {
+    const buildExample = (extern: Initialized) => {
+      const tracking = { runs: 0 };
+
+      const example = () => {
+        return extern.effect.named("abc").will(() => {
+          tracking.runs++;
+        });
+      };
+
+      return { example, tracking };
+    };
+
+    it("does not require the effect to be mocked", async () => {
+      const { example } = buildExample(extern);
+
+      await extern.testing(async () => {
+        await expect(example()).resolves.toBeUndefined();
+      });
+    });
+
+    it("suppresses execution of the original function", async () => {
+      const { example, tracking } = buildExample(extern);
+
+      await extern.testing(async () => {
+        await example();
+      });
+
+      expect(tracking.runs).toBe(0);
+    });
+
+    it("requires all spies to be used by the end of the block", async () => {
+      await expect(
+        extern.testing((mock) => {
+          mock.effect.named("abc").observe();
+        }),
+      ).rejects.toThrowError(UnusedMocksError);
+    });
+
+    describe("`passthrough()`", () => {
+      it("allows the original function to run", async () => {
+        const { example, tracking } = buildExample(extern);
+
+        await extern.testing(async (mock) => {
+          mock.effect.named("abc").passthrough();
+
+          await example();
+        });
+
+        expect(tracking.runs).toBe(1);
+      });
+    });
+
+    describe("outside of a testing block", () => {
+      it("runs the original function", async () => {
+        const { example, tracking } = buildExample(extern);
+
+        example();
+
+        expect(tracking.runs).toBe(1);
+      });
+    });
+
+    describe("after the `testing()` block", () => {
+      it("does not affect the original code path", async () => {
+        const { example, tracking } = buildExample(extern);
+
+        await extern.testing(async () => {
+          await example();
+        });
+
+        await example();
+
+        expect(tracking.runs).toBe(1);
+      });
+    });
+
+    describe("a spy", () => {
+      it("holds info of the effect", async () => {
+        await extern.testing(async (mock) => {
+          const { example } = buildExample(extern);
+
+          const spy = mock.effect.named("abc").observe();
+
+          expect(spy.kind).toBe("effect");
+          expect(spy.strategy).toEqual({ kind: "observe" });
+          expect(spy.named).toBe("abc");
+          expect(spy.specificity).toBe(1);
+
+          await example();
+        });
+      });
+
+      it("tracks executions", async () => {
+        await extern.testing(async (mock) => {
+          const { example } = buildExample(extern);
+
+          const spy = mock.effect.named("abc").observe();
+
+          await example();
+          await example();
+
+          expect(spy.executions).toMatchObject([
+            { mode: "effect", named: "abc" },
+            { mode: "effect", named: "abc" },
+          ]);
+        });
+      });
+
+      it("does not track executions of an effect of a different name", async () => {
+        await extern.testing(async (mock) => {
+          const example = (extern: Initialized) => {
+            extern.effect.named("abc").will(() => {});
+            extern.effect.named("xyz").will(() => {});
+          };
+
+          const spy = mock.effect.named("abc").observe();
+
+          await example(extern);
+
+          expect(spy.executions.length).toBe(1);
+          expect(spy.executions).toMatchObject([
+            { mode: "effect", named: "abc" },
+          ]);
+        });
+      });
+
+      describe("when accessed more than once for the same name", () => {
+        it("throws an error", async () => {
+          await expect(
+            extern.testing((mock) => {
+              const a = mock.effect.named("abc");
+              const b = mock.effect.named("abc");
+              a.observe();
+              b.observe();
+            }),
+          ).rejects.toThrowError(DuplicateMockError);
+        });
+      });
+
+      describe("of a passthrough mock", () => {
+        it("has a passthrough strategy", async () => {
+          await extern.testing(async (mock) => {
+            const { example } = buildExample(extern);
+
+            const spy = mock.effect.named("abc").passthrough();
+
+            expect(spy.strategy).toEqual({ kind: "passthrough" });
+
+            await example();
+          });
+        });
+
+        it("tracks executions", async () => {
+          await extern.testing(async (mock) => {
+            const { example } = buildExample(extern);
+
+            const spy = mock.effect.named("abc").passthrough();
+
+            await example();
+            await example();
+
+            expect(spy.executions).toMatchObject([
+              { mode: "effect", named: "abc" },
+              { mode: "effect", named: "abc" },
+            ]);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/testing/typed.test.ts
+++ b/test/testing/typed.test.ts
@@ -199,9 +199,9 @@ describe("`extern.testing`", async () => {
         await extern.testing((mock) => {
           const spy = mock(schema).with(123);
 
-          expect(spy.kind).toBe("mocked");
+          expect(spy.kind).toBe("value");
+          expect(spy.strategy).toEqual({ kind: "substitute", value: 123 });
           expect(spy.schema).toBe(schema);
-          expect(spy.value).toBe(123);
           expect(spy.specificity).toBe(0);
 
           example(extern);
@@ -227,13 +227,13 @@ describe("`extern.testing`", async () => {
             const spy1 = mock(schema).named("abc").with(9);
             const spy2 = mock(schema).with(27);
 
+            expect(spy1.strategy).toEqual({ kind: "substitute", value: 9 });
             expect(spy1.schema).toBe(schema);
-            expect(spy1.value).toBe(9);
             expect(spy1.specificity).toBe(1);
             expect(spy1.named).toEqual("abc");
 
+            expect(spy2.strategy).toEqual({ kind: "substitute", value: 27 });
             expect(spy2.schema).toBe(schema);
-            expect(spy2.value).toBe(27);
             expect(spy2.specificity).toBe(0);
 
             example(extern);
@@ -257,12 +257,12 @@ describe("`extern.testing`", async () => {
         });
       });
 
-      describe("of skipped mock", () => {
-        it("is of skipped kind", async () => {
+      describe("of a skipped mock", () => {
+        it("has a passthrough strategy", async () => {
           await extern.testing((mock) => {
             const spy = mock(schema).skip();
 
-            expect(spy.kind).toBe("skipped");
+            expect(spy.strategy).toEqual({ kind: "passthrough" });
 
             example(extern);
           });

--- a/test/testing/validated.test.ts
+++ b/test/testing/validated.test.ts
@@ -199,9 +199,9 @@ describe("`extern.testing`", async () => {
         await extern.testing(async (mock) => {
           const spy = mock(schema).with(123);
 
-          expect(spy.kind).toBe("mocked");
+          expect(spy.kind).toBe("value");
           expect(spy.schema).toBe(schema);
-          expect(spy.value).toBe(123);
+          expect(spy.strategy).toEqual({ kind: "substitute", value: 123 });
           expect(spy.specificity).toBe(0);
 
           await example(extern);
@@ -228,12 +228,12 @@ describe("`extern.testing`", async () => {
             const spy2 = mock(schema).with(27);
 
             expect(spy1.schema).toBe(schema);
-            expect(spy1.value).toBe(9);
+            expect(spy1.strategy).toEqual({ kind: "substitute", value: 9 });
             expect(spy1.specificity).toBe(1);
             expect(spy1.named).toEqual("abc");
 
             expect(spy2.schema).toBe(schema);
-            expect(spy2.value).toBe(27);
+            expect(spy2.strategy).toEqual({ kind: "substitute", value: 27 });
             expect(spy2.specificity).toBe(0);
 
             await example(extern);
@@ -257,12 +257,12 @@ describe("`extern.testing`", async () => {
         });
       });
 
-      describe("of skipped mock", () => {
-        it("is of skipped kind", async () => {
+      describe("of a skipped mock", () => {
+        it("has a passthrough strategy", async () => {
           await extern.testing(async (mock) => {
             const spy = mock(schema).skip();
 
-            expect(spy.kind).toBe("skipped");
+            expect(spy.strategy).toEqual({ kind: "passthrough" });
 
             await example(extern);
           });


### PR DESCRIPTION
Introduce a third extern mode, `effect`, for mocking side-effecting code that returns no value. Effect blocks are exposed via `extern.effect.will`, `extern.effect.named(name).will`, and `extern.effect.named(name).given(v).will`, and are mockable in tests via `mock.effect.named(name).observe()` or `mock.effect.named(name).passthrough()`. Only named effects are observable; unnamed effects are suppressed inside testing blocks and run normally outside them.

Restructure the spy data model around the new mode:

- Split the `kind` discriminator: `spy.kind` now distinguishes `"value"` vs `"effect"`, and the previous `"mocked" | "skipped"` is replaced by `spy.strategy.kind` (`"substitute" | "passthrough"` for value spies, `"observe" | "passthrough"` for effect spies).
- Move `$$Spy`, `$$Spyable`, and the new `$$Map` wrapper into `src/Spy.ts`.
- Split `$$Disambiguation` and `$$Params` into `$$ForValue` / `$$ForEffect` variants and add `"effect"` to `$$Mode`.
- Rename `typed/Will.ts` and `validated/Will.ts` to `Core.ts` and route effect blocks through a parallel `effect/Core.ts`.
- Extract `callerStack` and a new `augmentFunction` helper into `src/Util.ts`; use the latter to attach `.effect` to the existing `mock` callable.

Preserve the existing fluent API by aliasing `with`/`substitute` and `skip`/`passthrough` on value mocks. Audit `readonly` across `Config`, `Context`, and `Scope`. Add tests covering the effect surface and update typed/validated spy assertions to the new shape.

BREAKING CHANGES: 
- `spy.kind` no longer returns `"mocked"` or `"skipped"`.
- `spy.value` is gone — read `spy.strategy` instead.
- Unused `passthrough`/`skip` mocks now trigger `UnusedMocksError`; previously they were mistakenly exempt.